### PR TITLE
Fix pytorch dependancy issue

### DIFF
--- a/.github/workflows/nlp-timeline-gen-workflow.yml
+++ b/.github/workflows/nlp-timeline-gen-workflow.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
       - name: Install dependencies
         run: ./scripts/setup.sh
       - name: Lint python files with flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,8 +50,6 @@ tokenizers==0.12.1
 tomli==2.0.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==1.13.0+cpu
-torchaudio==0.13.0+cpu
-torchvision==0.14.0+cpu
 tqdm==4.64.1
 transformers==4.21.3
 typer==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,8 +51,8 @@ toml==0.10.2
 tomli==2.0.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==1.13.0+cpu
-torchaudio
-torchvision
+torchaudio==0.13.0+cpu
+torchvision==0.14.0+cpu
 tqdm==4.64.1
 transformers==4.21.3
 typer==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,8 +50,8 @@ tokenizers==0.12.1
 tomli==2.0.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==1.13.0+cpu
-torchaudio==0.12.1+cpu
-torchvision==0.13.1+cpu
+torchaudio==0.13.0+cpu
+torchvision==0.14.0+cpu
 tqdm==4.64.1
 transformers==4.21.3
 typer==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,3 +58,4 @@ typing_extensions==4.4.0
 urllib3==1.26.12
 wasabi==0.10.1
 Werkzeug==2.2.2
+wheel==0.38.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,8 +49,8 @@ thinc==8.1.4
 tokenizers==0.12.1
 tomli==2.0.1
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==1.12.1+cpu
-torchaudio==0.12.1+cpu
+torch==1.13.0+cpu
+torchaudio==0.13.0+cpu
 torchvision==0.13.1+cpu
 tqdm==4.64.1
 transformers==4.21.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,8 +51,8 @@ toml==0.10.2
 tomli==2.0.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==1.13.0+cpu
-torchaudio==0.13.0+cpu
-torchvision==0.14.0+cpu
+torchaudio
+torchvision
 tqdm==4.64.1
 transformers==4.21.3
 typer==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ PyYAML==6.0
 regex==2022.9.13
 requests==2.28.1
 smart-open==5.2.1
-spacy==3.4.1
+spacy==3.4.2
 spacy-alignments==0.8.6
 spacy-legacy==3.0.10
 spacy-loggers==1.0.3
@@ -47,11 +47,12 @@ spacy-transformers==1.1.8
 srsly==2.4.5
 thinc==8.1.4
 tokenizers==0.12.1
+toml==0.10.2
 tomli==2.0.1
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==1.12.1+cpu
-torchaudio==0.12.1+cpu
-torchvision==0.13.1+cpu
+torch==1.13.0+cpu
+torchaudio==0.13.0+cpu
+torchvision==0.14.0+cpu
 tqdm==4.64.1
 transformers==4.21.3
 typer==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,10 +49,9 @@ thinc==8.1.4
 tokenizers==0.12.1
 toml==0.10.2
 tomli==2.0.1
---extra-index-url https://download.pytorch.org/whl/cpu
 torch==1.13.0+cpu
-torchaudio==0.13.0
-torchvision==0.14.0
+torchaudio==0.13.0+cpu
+torchvision==0.14.0+cpu
 tqdm==4.64.1
 transformers==4.21.3
 typer==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,9 +49,9 @@ thinc==8.1.4
 tokenizers==0.12.1
 tomli==2.0.1
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==1.13.0+cpu
-torchaudio==0.13.0+cpu
-torchvision==0.13.0+cpu
+torch==1.12.1+cpu
+torchaudio==0.12.1+cpu
+torchvision==0.13.1+cpu
 tqdm==4.64.1
 transformers==4.21.3
 typer==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,8 +49,11 @@ thinc==8.1.4
 tokenizers==0.12.1
 toml==0.10.2
 tomli==2.0.1
+--extra-index-url https://download.pytorch.org/whl/cpu
 torch==1.13.0+cpu
+--extra-index-url https://download.pytorch.org/whl/cpu
 torchaudio==0.13.0+cpu
+--extra-index-url https://download.pytorch.org/whl/cpu
 torchvision==0.14.0+cpu
 tqdm==4.64.1
 transformers==4.21.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ itsdangerous==2.1.2
 Jinja2==3.1.2
 jq==1.3.0
 langcodes==3.3.0
-MarkupSafe==2.1.1
 mccabe==0.7.0
 murmurhash==1.0.9
 numpy==1.23.4
@@ -58,4 +57,3 @@ typing_extensions==4.4.0
 urllib3==1.26.12
 wasabi==0.10.1
 Werkzeug==2.2.2
-wheel==0.38.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,6 +50,8 @@ tokenizers==0.12.1
 tomli==2.0.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==1.13.0+cpu
+torchaudio==0.13.0+cpu
+torchvision==0.13.0+cpu
 tqdm==4.64.1
 transformers==4.21.3
 typer==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ tokenizers==0.12.1
 tomli==2.0.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==1.13.0+cpu
-torchaudio==0.13.0+cpu
+torchaudio==0.12.1+cpu
 torchvision==0.13.1+cpu
 tqdm==4.64.1
 transformers==4.21.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,10 +51,6 @@ toml==0.10.2
 tomli==2.0.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==1.13.0+cpu
---extra-index-url https://download.pytorch.org/whl/cpu
-torchaudio==0.13.0+cpu
---extra-index-url https://download.pytorch.org/whl/cpu
-torchvision==0.14.0+cpu
 tqdm==4.64.1
 transformers==4.21.3
 typer==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,6 +51,8 @@ toml==0.10.2
 tomli==2.0.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==1.13.0+cpu
+torchaudio==0.13.0
+torchvision==0.14.0
 tqdm==4.64.1
 transformers==4.21.3
 typer==0.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,8 +51,6 @@ toml==0.10.2
 tomli==2.0.1
 --extra-index-url https://download.pytorch.org/whl/cpu
 torch==1.13.0+cpu
-torchaudio==0.13.0+cpu
-torchvision==0.14.0+cpu
 tqdm==4.64.1
 transformers==4.21.3
 typer==0.4.2


### PR DESCRIPTION
Version 1.12.1 of pytorch was not being found. This turns out to be an issue with the version of python being used in the deployment pipeline.

Fixes: #60.