### PR TITLE
Prune false-positive character names from interactions matrix

### DIFF
--- a/backend/nlp.py
+++ b/backend/nlp.py
@@ -92,12 +92,6 @@ def normalise_matrix(matrix):
 
 
 def calculate_threshold(values, percentile):
-    # mean = np.mean(values[values > 0])
-    # std = np.std(values[values > 0])
-    # print(values[values > 0])
-    # print("mean ", mean)
-    # print("std" , std)
-    # return mean - std
     values = values[values > 0]
     return np.percentile(values, percentile)
 
@@ -109,8 +103,8 @@ def prune_matrices(matrices, characters_timeline, quiet, percentile):
         ch: matrices[-1][:, characters_timeline[-1].index(ch)].sum() for ch in characters_timeline[-1]
     }
     threshold = calculate_threshold(np.fromiter(characters_interactions.values(), dtype=int), percentile)
-    # np.percentile(np.fromiter(characters_interactions.values(), dtype=int), PRUNING_PERCENTILE)
-    print("threshold ", threshold)
+    if not quiet:
+        print("Threshold: ", threshold)
     unimportant_characters = [ch for (ch, x) in characters_interactions.items() if x < threshold]
 
     for i in range(len(matrices)):

--- a/chronolog.py
+++ b/chronolog.py
@@ -6,7 +6,7 @@ from argparse import RawTextHelpFormatter, ArgumentParser
 
 DEFAULT_SPLITS = 10
 
-# Just chapter number as roman numeral, e.g. IX
+# Just chapter number as roman numeral, e.g. IX \n\n
 NUMERAL_PATTERN = re.compile(
     r"""M{0,3}(?:CM|CD|D?C{0,3})?(?:XC|XL|L?X{0,3})?(?:IX|IV|V?I{0,3})?\n\n$""",
     re.IGNORECASE)
@@ -14,7 +14,7 @@ NUMERAL_PATTERN = re.compile(
 CHAPTER_NUMERAL_PATTERN = re.compile(
     r"""(?:Chapter M{0,3}(?:CM|CD|D?C{0,3})?(?:XC|XL|L?X{0,3})?(?:IX|IV|V?I{0,3})?)""",
     re.IGNORECASE)
-# Just chapter number, e.g. 9
+# Just chapter number, e.g. 9 \n\n
 DIGIT_PATTERN = re.compile(r"""[0-9]+\n\n""", re.VERBOSE)
 # Chapter with number, e.g. Chapter 9
 CHAPTER_DIGIT_PATTERN = re.compile(r"""Chapter [0-9]+""", re.IGNORECASE)

--- a/chronolog.py
+++ b/chronolog.py
@@ -5,6 +5,7 @@ import backend.nlp as nlp
 from argparse import RawTextHelpFormatter, ArgumentParser
 
 DEFAULT_SPLITS = 10
+DEFAULT_PERCENTILE = 50
 
 # Just chapter number as roman numeral, e.g. IX \n\n
 NUMERAL_PATTERN = re.compile(
@@ -50,6 +51,12 @@ def main():
     )
     parser.add_argument('--quiet', '-q', required=False, action='store_true',
                         help="Suppresses updates on progress of model.")
+    parser.add_argument('--percentile', '-p', required=False, type=int, default=DEFAULT_PERCENTILE,
+                        choices=range(0, 101),
+                        help="Percentile threshold below which names will be disregarded. Defaults to {}.".format(
+                            DEFAULT_PERCENTILE))
+    parser.add_argument('--unpruned', '-u', required=False, action='store_true',
+                        help="Perform no pruning on output matrix.")
     parser.add_argument(
         '--title',
         '-t',
@@ -57,7 +64,7 @@ def main():
         type=str,
         metavar="T",
         help="Provide novel title, if it is not the same as the file name. " +
-        "The analysis will be stored in {title}_analysis.json if this argument is given.")
+             "The analysis will be stored in {title}_analysis.json if this argument is given.")
     parser.add_argument(
         '--sections',
         '-s',
@@ -66,7 +73,7 @@ def main():
         metavar="N",
         default=DEFAULT_SPLITS,
         help="Supply the number of sections you want to divide your book into. " +
-        "The timeline will then be created in N similar sized sections. Default N = {}.".format(DEFAULT_SPLITS))
+             "The timeline will then be created in N similar sized sections. Default N = {}.".format(DEFAULT_SPLITS))
 
     args = parser.parse_args()
     with open(args.filename, 'r') as f:
@@ -84,7 +91,7 @@ def main():
         pattern,
         args.sections or DEFAULT_SPLITS,
         args.quiet)
-    nlp.generate_timeline_json(sections, title, args.quiet)
+    nlp.generate_timeline_json(sections, title, args.quiet, args.unpruned, args.percentile)
 
 
 if __name__ == "__main__":

--- a/tests/generate_interactions_matrix_test.py
+++ b/tests/generate_interactions_matrix_test.py
@@ -13,7 +13,7 @@ files = [filename.split('.')[0] for filename in os.listdir(TEXT_DIRECTORY)]
 def test_interactions_matrix(test_name):
     with open(os.path.join(TEXT_DIRECTORY, test_name + '.txt'), 'r') as f:
         text = f.read()
-    actual = nlp.generate_interactions_matrix(text, [], [])[0]
+    actual = nlp.normalise_matrix(nlp.generate_interactions_matrix(text, [], [])[0])
     expected = np.loadtxt(
         os.path.join(
             CSV_DIRECTORY,


### PR DESCRIPTION
Implemented a percentile appearance threshold under which a 'character name' as identified by Spacy entity recognition is pruned from the interactions matrices. This means Spacy's sometimes questionable entity recognition has less of an impact on the final set of interactions matrices.
Fixes #77 