### PR TITLE
Improve pipeline performance

### DIFF
--- a/.github/workflows/nlp-timeline-gen-workflow.yml
+++ b/.github/workflows/nlp-timeline-gen-workflow.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
       - name: Install dependencies
         run: |
           cd client
@@ -36,7 +36,7 @@ jobs:
           cd client
           npm run build
       - name: Temporarily save build
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: client-build
           path: client/build
@@ -48,7 +48,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Retrieve saved build
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: client-build
           path: client/build

--- a/.github/workflows/nlp-timeline-gen-workflow.yml
+++ b/.github/workflows/nlp-timeline-gen-workflow.yml
@@ -1,4 +1,4 @@
-name: check and deploy
+name: Check and deploy
 on: push
 jobs:
   test:
@@ -19,37 +19,39 @@ jobs:
         run: ./scripts/check_web_formatting.sh
       - name: Test with pytest
         run: ./scripts/run_py_tests.sh
+
   prod-build:
     needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
-      - name: install dependencies
+      - name: Install dependencies
         run: |
           cd client
           sudo apt install npm
           npm install
-      - name: build
+      - name: Build
         run: |
           cd client
           npm run build
+      - name: Temporarily save build
+        uses: actions/upload-artifact@v2
+        with:
+          name: client-build
+          path: client/build
+          retention-days: 1
+
   prod-deploy:
     needs: prod-build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v2
-      - name: install dependencies
-        run: |
-          cd client
-          sudo apt install npm
-          npm install
-      - name: build
-        run: |
-          cd client
-          npm run build
+      - name: Retrieve saved build
+        uses: actions/download-artifact@v2
+        with:
+          name: client-build
+          path: client/build
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@v4
         with:


### PR DESCRIPTION
Temporarily cache the built version of the react app on GitHub so that it doesn't need to be built in both the prod-build and prod-deploy stages. This should significantly speed up the pipeline as installing the dependencies takes a large amount of time.

Fixes: #88.