### PR TITLE
Change library cards to use book titles instead of filenames

### DIFF
--- a/client/src/Home.js
+++ b/client/src/Home.js
@@ -1,8 +1,12 @@
-import React from "react";
+import React, {useEffect} from "react";
 import "./App.css";
 import "bootstrap/dist/css/bootstrap.min.css";
 
 function Home() {
+    useEffect(() => {
+        document.body.style.backgroundColor = "#eae0d5";
+    });
+
   return (
     <>
       <div class="chronolog-header px-3 py-3 pt-md-5 pb-md-4 mx-auto text-center">

--- a/client/src/Home.js
+++ b/client/src/Home.js
@@ -1,11 +1,11 @@
-import React, {useEffect} from "react";
+import React, { useEffect } from "react";
 import "./App.css";
 import "bootstrap/dist/css/bootstrap.min.css";
 
 function Home() {
-    useEffect(() => {
-        document.body.style.backgroundColor = "#eae0d5";
-    });
+  useEffect(() => {
+    document.body.style.backgroundColor = "#eae0d5";
+  });
 
   return (
     <>

--- a/client/src/Library.js
+++ b/client/src/Library.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, {useEffect, useState} from "react";
 import Card from "react-bootstrap/Card";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
@@ -6,32 +6,63 @@ import "./App.css";
 import "./Library.css";
 
 function Library() {
-  useEffect(() => {
-    document.body.style.backgroundColor = "#eae0d5";
-  });
+    useEffect(() => {
+        document.body.style.backgroundColor = "#eae0d5";
+    });
 
-  let files = require.context("../public/library/", false, /\.json$/);
-  files = files.keys().map((filename) => filename.slice(2, -5));
+    const [bookTitles, setBookTitles] = useState([])
+    const [loading, setLoading] = useState(true)
 
-  return (
-    <div className="books">
-      <Row xs={1} md={2} lg={4} className="g-4">
-        {files.map((filename) => (
-          <Col>
-            <Card className="text-center">
-              <Card.Img variant="top" src="../ChronoLogoMini.png" />
-              <Card.Body>
-                <Card.Title>{filename.replaceAll("_", " ")}</Card.Title>
-                <a href={filename} class="btn stretched-link">
-                  View graph
-                </a>
-              </Card.Body>
-            </Card>
-          </Col>
-        ))}
-      </Row>
-    </div>
-  );
+    let filePaths = require.context("../public/library/", false, /\.json$/);
+    filePaths = filePaths.keys();
+
+    let newTitles = []
+
+    async function getData(filename) {
+        setLoading(true);
+        await fetch(filename).then(response => {
+            console.log(filename + ' being fetched')
+            if (response.ok) {
+                return response.json()
+            }
+            throw response;
+        }).then(data => {
+            newTitles.push(data["book"])
+            console.log(newTitles)
+        }).finally(() => {setLoading(false)});
+    }
+
+    function getAllData() {
+        newTitles = []
+        return Promise.all(filePaths.map(filename => getData(filename)))
+    }
+
+    useEffect(() => {
+        getAllData().then(setBookTitles(newTitles))
+        console.log(bookTitles)
+    }, []);
+
+    if (loading) return "Loading..."
+
+    return (
+        <div className="books">
+            <Row xs={1} md={2} lg={4} className="g-4">
+                {bookTitles.map((bookTitle) => (
+                    <Col>
+                        <Card className="text-center">
+                            <Card.Img variant="top" src="../ChronoLogoMini.png"/>
+                            <Card.Body>
+                                <Card.Title>{bookTitle}</Card.Title>
+                                <a href='' className="btn stretched-link">
+                                    View graph
+                                </a>
+                            </Card.Body>
+                        </Card>
+                    </Col>
+                ))}
+            </Row>
+        </div>
+    );
 }
 
 export default Library;

--- a/client/src/Library.js
+++ b/client/src/Library.js
@@ -41,10 +41,9 @@ function Library() {
     ).then((data) => {
       console.log("Post Promise.all", data);
       newTitles = [];
-      data.map((d1) => {
+      data.forEach((d1) => {
         newTitles.push(d1["book"]);
       });
-
       setBookTitles(newTitles);
     });
   }, []);
@@ -52,13 +51,13 @@ function Library() {
   return (
     <div className="books">
       <Row xs={1} md={2} lg={4} className="g-4">
-        {bookTitles.map((bookTitle) => (
+        {bookTitles.map((bookTitle, index) => (
           <Col>
             <Card className="text-center">
               <Card.Img variant="top" src="../ChronoLogoMini.png" />
               <Card.Body>
                 <Card.Title>{bookTitle}</Card.Title>
-                <a href="" className="btn stretched-link">
+                <a href={filePaths[index].slice(2, -5)} className="btn stretched-link">
                   View graph
                 </a>
               </Card.Body>

--- a/client/src/Library.js
+++ b/client/src/Library.js
@@ -57,7 +57,10 @@ function Library() {
               <Card.Img variant="top" src="../ChronoLogoMini.png" />
               <Card.Body>
                 <Card.Title>{bookTitle}</Card.Title>
-                <a href={filePaths[index].slice(2, -5)} className="btn stretched-link">
+                <a
+                  href={filePaths[index].slice(2, -5)}
+                  className="btn stretched-link"
+                >
                   View graph
                 </a>
               </Card.Body>

--- a/client/src/Library.js
+++ b/client/src/Library.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from "react";
+import React, { useEffect, useState } from "react";
 import Card from "react-bootstrap/Card";
 import Col from "react-bootstrap/Col";
 import Row from "react-bootstrap/Row";
@@ -6,65 +6,68 @@ import "./App.css";
 import "./Library.css";
 
 function Library() {
-    useEffect(() => {
-        document.body.style.backgroundColor = "#eae0d5";
+  useEffect(() => {
+    document.body.style.backgroundColor = "#eae0d5";
+  });
+
+  const [bookTitles, setBookTitles] = useState([]);
+  // const [loading, setLoading] = useState(true)
+
+  let filePaths = require.context("../public/library/", false, /\.json$/);
+  filePaths = filePaths.keys();
+
+  let newTitles = [];
+
+  function checkStatus(response) {
+    if (response.ok) {
+      return Promise.resolve(response);
+    } else {
+      return Promise.reject(new Error(response.statusText));
+    }
+  }
+
+  function parseJSON(response) {
+    return response.json();
+  }
+
+  useEffect(() => {
+    Promise.all(
+      filePaths.map((fp) =>
+        fetch(fp)
+          .then(checkStatus)
+          .then(parseJSON)
+          .catch((error) => console.log("There was a problem", error))
+      )
+    ).then((data) => {
+      console.log("Post Promise.all", data);
+      newTitles = [];
+      data.map((d1) => {
+        newTitles.push(d1["book"]);
+      });
+
+      setBookTitles(newTitles);
     });
+  }, []);
 
-    const [bookTitles, setBookTitles] = useState([])
-    // const [loading, setLoading] = useState(true)
-
-    let filePaths = require.context("../public/library/", false, /\.json$/);
-    filePaths = filePaths.keys();
-
-    let newTitles = []
-
-    function checkStatus(response) {
-        if(response.ok) {
-            return Promise.resolve(response);
-        } else {
-            return Promise.reject(new Error(response.statusText));
-        }
-    }
-
-    function parseJSON(response) {
-        return response.json();
-    }
-
-    useEffect(() => {
-        Promise.all(filePaths.map(fp => fetch(fp)
-            .then(checkStatus)
-            .then(parseJSON)
-            .catch(error => console.log('There was a problem',error))))
-            .then(data => {
-                console.log('Post Promise.all',data);
-                newTitles=[]
-                data.map( d1 => {
-                    newTitles.push(d1["book"]);
-                })
-
-                setBookTitles(newTitles);
-            })
-    }, []);
-
-    return (
-        <div className="books">
-            <Row xs={1} md={2} lg={4} className="g-4">
-                {bookTitles.map((bookTitle) => (
-                    <Col>
-                        <Card className="text-center">
-                            <Card.Img variant="top" src="../ChronoLogoMini.png"/>
-                            <Card.Body>
-                                <Card.Title>{bookTitle}</Card.Title>
-                                <a href='' className="btn stretched-link">
-                                    View graph
-                                </a>
-                            </Card.Body>
-                        </Card>
-                    </Col>
-                ))}
-            </Row>
-        </div>
-    );
+  return (
+    <div className="books">
+      <Row xs={1} md={2} lg={4} className="g-4">
+        {bookTitles.map((bookTitle) => (
+          <Col>
+            <Card className="text-center">
+              <Card.Img variant="top" src="../ChronoLogoMini.png" />
+              <Card.Body>
+                <Card.Title>{bookTitle}</Card.Title>
+                <a href="" className="btn stretched-link">
+                  View graph
+                </a>
+              </Card.Body>
+            </Card>
+          </Col>
+        ))}
+      </Row>
+    </div>
+  );
 }
 
 export default Library;


### PR DESCRIPTION
I changed the library cards to use book titles found under "book" in every json file we have in public/library. The library now displays the book title for every card. 

Fixes #134 